### PR TITLE
Fix criterion benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ memmap2 = "0.9"
 [dev-dependencies]
 criterion = "0.6"
 tempfile = "3"
+
+[[bench]]
+name = "io_bench"
+harness = false

--- a/benches/io_bench.rs
+++ b/benches/io_bench.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use rffio::{read_buffered, read_mmap, write_buffered, write_mmap};
 use tempfile::NamedTempFile;
-use std::io::Write;
 
 const SIZE: usize = 10 * 1024 * 1024; // 10MB
 


### PR DESCRIPTION
## Summary
- remove unused import in `io_bench`
- configure benchmark harness for Criterion

## Testing
- `cargo test`
- `cargo bench --bench io_bench -- --sample-size 10 --quiet`