### PR TITLE
Add benchmark result collection script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+benchmark_results/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Rust Fast File IO Experiments
 
-This project benchmarks different approaches to reading and writing files in Rust. It
-currently compares buffered I/O with memory–mapped files using [criterion].
+This project benchmarks different approaches to reading and writing files in Rust. It currently compares buffered I/O with memory–mapped files using [criterion].
 
 ## Running the benchmarks
 
@@ -9,7 +8,16 @@ currently compares buffered I/O with memory–mapped files using [criterion].
 cargo bench
 ```
 
-The benchmarks will create temporary 10–MB files for each iteration and measure the
-speed of reading and writing them with the available methods.
+The benchmarks will create temporary 10–MB files for each iteration and measure the speed of reading and writing them with the available methods.
+
+## Collecting results
+
+A helper script is provided to run the benchmarks and write a Markdown summary to `benchmark_results/results.md`:
+
+```bash
+./scripts/run_benchmarks.sh
+```
+
+The generated table can be included in this README to document the latest performance numbers.
 
 [criterion]: https://github.com/bheisler/criterion.rs

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SAMPLE_SIZE=${SAMPLE_SIZE:-10}
+OUTPUT_DIR="benchmark_results"
+mkdir -p "$OUTPUT_DIR"
+
+# Run criterion benchmarks
+cargo bench --bench io_bench -- --noplot --sample-size "$SAMPLE_SIZE" > "$OUTPUT_DIR/raw_output.txt"
+
+BENCHES=(write_buffered write_mmap read_buffered read_mmap)
+RESULTS_MD="$OUTPUT_DIR/results.md"
+echo "| Benchmark | Time (ms) |" > "$RESULTS_MD"
+echo "|-----------|---------:|" >> "$RESULTS_MD"
+
+for b in "${BENCHES[@]}"; do
+    JSON="target/criterion/$b/new/estimates.json"
+    if [ -f "$JSON" ]; then
+        ns=$(jq '.mean.point_estimate' "$JSON")
+        ms=$(awk -v val="$ns" 'BEGIN{printf "%.3f", val/1e6}')
+        echo "| $b | $ms |" >> "$RESULTS_MD"
+    fi
+done
+
+echo "Results written to $RESULTS_MD"


### PR DESCRIPTION
## Summary
- add `run_benchmarks.sh` helper to run criterion benches and summarise results
- document how to run the new script in `README.md`
- ignore generated benchmark results directory

## Testing
- `./scripts/run_benchmarks.sh > /tmp/bench.log && tail -n 20 /tmp/bench.log`