### PR TITLE
Refactor IO into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project benchmarks different approaches to reading and writing files in Rust. It currently compares buffered I/O with memory–mapped files using [criterion].
 
+The I/O operations are organized into modules under `src/io`. Each method implements the `IoMethod` trait, so new strategies can be added by providing another implementation.
+
 ## Running the benchmarks
 
 ```bash

--- a/src/io/buffered.rs
+++ b/src/io/buffered.rs
@@ -1,0 +1,32 @@
+use std::fs::File;
+use std::io::{self, Read, Write, BufReader, BufWriter};
+use std::path::Path;
+
+use super::IoMethod;
+
+pub struct Buffered;
+
+impl IoMethod for Buffered {
+    fn write(path: &Path, data: &[u8]) -> io::Result<()> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::new(file);
+        writer.write_all(data)?;
+        writer.flush()
+    }
+
+    fn read(path: &Path) -> io::Result<usize> {
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).map(|size| size)
+    }
+}
+
+// Keep function style API for backward compatibility
+pub fn write_buffered(path: &Path, data: &[u8]) -> io::Result<()> {
+    Buffered::write(path, data)
+}
+
+pub fn read_buffered(path: &Path) -> io::Result<usize> {
+    Buffered::read(path)
+}

--- a/src/io/mmap.rs
+++ b/src/io/mmap.rs
@@ -1,0 +1,38 @@
+use std::fs::{File, OpenOptions};
+use std::io::{self};
+use std::path::Path;
+
+use memmap2::{Mmap, MmapMut};
+
+use super::IoMethod;
+
+pub struct MmapIo;
+
+impl IoMethod for MmapIo {
+    fn write(path: &Path, data: &[u8]) -> io::Result<()> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        file.set_len(data.len() as u64)?;
+        let mut mmap = unsafe { MmapMut::map_mut(&file)? };
+        mmap[..].copy_from_slice(data);
+        mmap.flush()
+    }
+
+    fn read(path: &Path) -> io::Result<usize> {
+        let file = File::open(path)?;
+        let mmap = unsafe { Mmap::map(&file)? };
+        Ok(mmap.len())
+    }
+}
+
+pub fn write_mmap(path: &Path, data: &[u8]) -> io::Result<()> {
+    MmapIo::write(path, data)
+}
+
+pub fn read_mmap(path: &Path) -> io::Result<usize> {
+    MmapIo::read(path)
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,13 @@
+use std::io;
+use std::path::Path;
+
+pub trait IoMethod {
+    fn write(path: &Path, data: &[u8]) -> io::Result<()>;
+    fn read(path: &Path) -> io::Result<usize>;
+}
+
+pub mod buffered;
+pub mod mmap;
+
+pub use buffered::{read_buffered, write_buffered, Buffered};
+pub use mmap::{read_mmap, write_mmap, MmapIo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,41 +1,6 @@
-use std::fs::{File, OpenOptions};
-use std::io::{self, Read, Write, BufReader, BufWriter};
-use std::path::Path;
+pub mod io;
 
-use memmap2::{Mmap, MmapMut};
-
-pub fn write_buffered(path: &Path, data: &[u8]) -> io::Result<()> {
-    let file = File::create(path)?;
-    let mut writer = BufWriter::new(file);
-    writer.write_all(data)?;
-    writer.flush()
-}
-
-pub fn read_buffered(path: &Path) -> io::Result<usize> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let mut buf = Vec::new();
-    reader.read_to_end(&mut buf).map(|size| size)
-}
-
-pub fn write_mmap(path: &Path, data: &[u8]) -> io::Result<()> {
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path)?;
-    file.set_len(data.len() as u64)?;
-    let mut mmap = unsafe { MmapMut::map_mut(&file)? };
-    mmap[..].copy_from_slice(data);
-    mmap.flush()
-}
-
-pub fn read_mmap(path: &Path) -> io::Result<usize> {
-    let file = File::open(path)?;
-    let mmap = unsafe { Mmap::map(&file)? };
-    Ok(mmap.len())
-}
+pub use io::{read_buffered, read_mmap, write_buffered, write_mmap};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- organize `Buffered` and `Mmap` IO logic under `src/io`
- expose an `IoMethod` trait to make adding new strategies easy
- update docs

## Testing
- `cargo test`